### PR TITLE
Search bar

### DIFF
--- a/src/app/frontend/assets/styles/modules/m-search-overlay.scss
+++ b/src/app/frontend/assets/styles/modules/m-search-overlay.scss
@@ -2,6 +2,7 @@
 
 .m-search-overlay {
   @include overlay-wrap-transparent;
+  color:inherit;
 }
 
 .m-search-overlay > h1 {
@@ -93,8 +94,8 @@
 }
 
 .m-search-overlay .helper-text {
-  display: block;
-  margin-bottom: 6px;
+  margin-bottom: 0;
+  font-size: 14px;
 }
 
 // Date range

--- a/src/app/frontend/components/forms/search/search_view.js
+++ b/src/app/frontend/components/forms/search/search_view.js
@@ -278,7 +278,7 @@ import {recordEvent} from "../../../config/data_layer";
 
               <div className="form-group form-group--primary-field">
                 <input placeholder="Enter a topic…" type="text" name="q" onKeyUp={this.handleKeyUp.bind(this)} value={this.state.q} onChange={this.handleOnChange.bind(this)} />
-                <p style={{color: 'grey'}}>You can use quotation marks to match your exact search term.</p>
+                <p className="helper-text">You can use quotation marks to match your exact search term.</p>
               </div>
 
               <div className="date-range">

--- a/src/app/frontend/components/forms/search/search_view.js
+++ b/src/app/frontend/components/forms/search/search_view.js
@@ -277,7 +277,7 @@ import {recordEvent} from "../../../config/data_layer";
               </div>
 
               <div className="form-group form-group--primary-field">
-                <input placeholder="Enter a topic or place…" type="text" name="q" onKeyUp={this.handleKeyUp.bind(this)} value={this.state.q} onChange={this.handleOnChange.bind(this)} />
+                <input placeholder="Enter a topic…" type="text" name="q" onKeyUp={this.handleKeyUp.bind(this)} value={this.state.q} onChange={this.handleOnChange.bind(this)} />
               </div>
 
               <div className="date-range">

--- a/src/app/frontend/components/forms/search/search_view.js
+++ b/src/app/frontend/components/forms/search/search_view.js
@@ -278,6 +278,7 @@ import {recordEvent} from "../../../config/data_layer";
 
               <div className="form-group form-group--primary-field">
                 <input placeholder="Enter a topic…" type="text" name="q" onKeyUp={this.handleKeyUp.bind(this)} value={this.state.q} onChange={this.handleOnChange.bind(this)} />
+                <p style={{color: 'grey'}}>You can use quotation marks to match your exact search term.</p>
               </div>
 
               <div className="date-range">

--- a/src/app/views/pages/_big_search.html.erb
+++ b/src/app/views/pages/_big_search.html.erb
@@ -5,6 +5,6 @@
             <%= text_field_tag :q, nil, placeholder: "Search records on the map" %>
             <%= submit_tag 'Go' %>
         </div>
-        <p>Search for a place or topic you’re interested in…</p>
+        <p>Search for a topic you’re interested in…</p>
     </div>
 <% end %>


### PR DESCRIPTION
This PR addresses issues #498 and #476.

We have deleted the word "place" from both the map search bar and the search bar on the homepage.

We have also added text underneath the search bar to advise the user that searching with quotation marks will give them a result matching their input.

@andyError I would appreciate a review of the styling. Thank you ❤️ 